### PR TITLE
Bug report tuning

### DIFF
--- a/clair/clair.go
+++ b/clair/clair.go
@@ -20,6 +20,8 @@ type JiraTicket struct {
 	Description string
 	DevTeam     string
 	Assignee    string
+	Priority    string
+	Severity    string
 }
 
 type TeamRepositories struct {

--- a/clair/clair.go
+++ b/clair/clair.go
@@ -22,6 +22,7 @@ type JiraTicket struct {
 	Assignee    string
 	Priority    string
 	Severity    string
+	Version     string
 }
 
 type TeamRepositories struct {

--- a/cmd/clair_reporter/main.go
+++ b/cmd/clair_reporter/main.go
@@ -66,9 +66,21 @@ func reportClairFindings(file *os.File, repositoryTeams, repositoryAssignees map
 			repo := strings.SplitN(klarReport.Repo, "/", 2)[1]
 			jiraTicket.Repo = repo
 			jiraTicket.Package = pkg
+			priority := "P2"
+			severity := "Sev-2"
+			for _, feature := range vuln {
+				if feature.Severity == "Critical" ||
+					feature.Severity == "Defcon1" {
+					priority = "P1"
+					severity = "Sev-1"
+					break
+				}
+			}
 			jiraTicket.Description = featuresToJSON(vuln)
 			jiraTicket.DevTeam = repositoryTeams[repo]
 			jiraTicket.Assignee = repositoryAssignees[repo]
+			jiraTicket.Priority = priority
+			jiraTicket.Severity = severity
 			if err := r.Report(jiraTicket); err != nil {
 				log.Printf("Cannot generate report with %s: %s", n, err)
 			}

--- a/reporter/jira.go
+++ b/reporter/jira.go
@@ -35,7 +35,7 @@ func init() {
 			username = flag.String("JIRA_USERNAME", "", "JIRA user to authenticate as")
 			token = flag.String("JIRA_TOKEN", "", "JIRA token for the user to authenticate")
 			// TODO: Turn this into a file-path argument to use a template file instead of string
-			fieldsConfiguration = flag.String("JIRA_FIELDS", "Project|CD;Issue Type|Story;Summary|Container Security Vulnerability: container name:{{ .failure.Repo }}, package name:{{ .failure.Package }};Description|{{ .failure.Description }};Component/s|Platform Security;Dev Team|{{ .failure.DevTeam }};Assignee|{{ .failure.Assignee }};Priority|P2;Severity|Sev-2;Vulnerability Report By|Clair;Labels|security_infrastructure", "JIRA fields in 'key|value;...' format seperated by ';', this configuration MUST contain 'Project', 'Summary' and 'Issue Type'")
+			fieldsConfiguration = flag.String("JIRA_FIELDS", "Project|CD;Issue Type|Bug;Summary|Container Security Vulnerability: container name:{{ .failure.Repo }}, package name:{{ .failure.Package }};Description|{{ .failure.Description }};Component/s|Platform Security;Dev Team|{{ .failure.DevTeam }};Assignee|{{ .failure.Assignee }};Priority|{{ .failure.Priority }};Severity|{{ .failure.Severity }};Vulnerability Report By|Clair;Labels|security_infrastructure", "JIRA fields in 'key|value;...' format seperated by ';', this configuration MUST contain 'Project', 'Summary' and 'Issue Type'")
 			closedStatus = flag.String("JIRA_ISSUE_CLOSED_STATUS", "Closed", "The status of JIRA issue when it is considered closed")
 		},
 


### PR DESCRIPTION
# Tuning the bug reports

added the ability to change priority based on the severity of vulnerabilities found 

```
critical, defcon1 - p1
medium,high - p2
```
For now we have removed lower than medium vulnerabilities

changed the issue type to be a bug

Added default options for version, team and assignee which are passed through the command line.

We have removed the call to CheckCompleteAndAvailable for the fields as it is buggy and missed a mapping from versions to Affects Version/s which was an alias. Jira returns the missing fields in the response and some of the required fields were missing due to aliases.